### PR TITLE
fix: nuxt config bug

### DIFF
--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -71,6 +71,12 @@ export default {
     locales: ['en'],
     defaultLocale: 'en',
     strategy: 'no_prefix',
+    currency: 'USD',
+    country: 'US',
+    currencies: [
+      { name: 'USD', label: 'Dollar' },
+      { name: 'EUR', label: 'Euro' }
+    ],
     vueI18n: {
       fallbackLocale: 'en',
       messages: {


### PR DESCRIPTION

## Description
Add currency and country properties to nuxt config to make theme working. 

## Related Issue
https://github.com/vuestorefront/woocommerce/issues/2 

## Motivation and Context


## How Has This Been Tested?
You can now run project without error. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
